### PR TITLE
 use "prop-types" package for compatibility with React >= 16.0

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { requireNativeComponent } from 'react-native';
+import PropTypes from "prop-types";
 
 export default class ScrollBlockView extends React.Component {
   render() {
@@ -8,7 +9,7 @@ export default class ScrollBlockView extends React.Component {
 }
 
 ScrollBlockView.propTypes = {
-  blocked: React.PropTypes.bool,
+  blocked: PropTypes.bool,
 };
 
 var RCTScrollBlockView = requireNativeComponent('RCTScrollBlockView', ScrollBlockView);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,18 @@
 {
   "name": "react-native-scroll-block-view",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "nativePackage": true,
   "keywords": [
     "react-native",
     "native-modules"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "main": "./index.ios.js",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-scroll-block-view",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "nativePackage": true,
   "keywords": [
     "react-native",


### PR DESCRIPTION
The current version causes a red box or crash with current react-native versions (e.g., RN v0.55.x) because React.PropTypes doesn't exist on React versions >= 16.0.

Therefore, I migrated the project to use the new "prop-types" package instead and updated the package.json accordingly.